### PR TITLE
remove options from swagger

### DIFF
--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -73,6 +73,9 @@ def build_spec(app, loop):
 
         methods = {}
         for _method, _handler in method_handlers:
+            if _method == 'OPTIONS':
+                continue
+            
             route_spec = route_specs.get(_handler) or RouteSpec()
             consumes_content_types = route_spec.consumes_content_type or \
                 getattr(app.config, 'API_CONSUMES_CONTENT_TYPES', ['application/json'])


### PR DESCRIPTION
I don't think options should ever be in swagger. There really isn't much of a use for it as the point of it is to..... see the options, which swagger shows you. I think this will fix it