### PR TITLE
Remove OPTIONS methods from swagger

### DIFF
--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -73,6 +73,9 @@ def build_spec(app, loop):
 
         methods = {}
         for _method, _handler in method_handlers:
+            if _method == 'OPTIONS':
+                continue
+            
             route_spec = route_specs.get(_handler) or RouteSpec()
             consumes_content_types = route_spec.consumes_content_type or \
                 getattr(app.config, 'API_CONSUMES_CONTENT_TYPES', ['application/json'])
@@ -80,7 +83,7 @@ def build_spec(app, loop):
                 getattr(app.config, 'API_PRODUCES_CONTENT_TYPES', ['application/json'])
 
             endpoint = remove_nulls({
-                'operationId': route_spec.operation or _handler.__name__,
+                'operationId': route_spec.operation or route.name,
                 'summary': route_spec.summary,
                 'description': route_spec.description,
                 'consumes': consumes_content_types,


### PR DESCRIPTION
The purpose of options is to show the HTTP methods that the server supports for the route: https://www.w3schools.com/tags/ref_httpmethods.asp

Since you are generating a swagger, they don't need to be there.

Additionally, i think the operationId should be the route.name rather than the _handler.__name__ as if someone is using blueprints then there may be multiple routes that have the same operationId and that is against the swagger spec: http://swagger.io/specification/

Specifically this line:

operationId	string	Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.