### PR TITLE
Add a rudimentary support for floats.

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -28,6 +28,15 @@ class Integer(Field):
         }
 
 
+class Float(Field):
+    def serialize(self):
+        return {
+            "type": "number",
+            "format": "double",
+            **super().serialize()
+        }
+
+
 class String(Field):
     def serialize(self):
         return {
@@ -145,6 +154,8 @@ def serialize_schema(schema):
             return List().serialize()
         elif schema is int:
             return Integer().serialize()
+        elif schema is float:
+            return Float().serialize()
         elif schema is str:
             return String().serialize()
         elif schema is bool:


### PR DESCRIPTION
A step up could be adding a clean way to choose the format of the float.
I was thinking about having a const list to check against, since it's clearly specified.

This just occurred to me: Should we want to have the schema itself be a `Numeric`, and have it mapped to a float?

Anyways, any input is welcome.