### PR TITLE
Add exclude decorator that removes route from docs

### DIFF
--- a/sanic_openapi/doc.py
+++ b/sanic_openapi/doc.py
@@ -185,6 +185,7 @@ class RouteSpec:
     operation = None
     blueprint = None
     tags = None
+    exclude = None
 
     def __init__(self):
         self.tags = []
@@ -195,7 +196,8 @@ route_specs = defaultdict(RouteSpec)
 
 
 def route(summary=None, description=None, consumes=None, produces=None,
-          consumes_content_type=None, produces_content_type=None):
+          consumes_content_type=None, produces_content_type=None,
+          exclude=None):
     def inner(func):
         route_spec = route_specs[func]
 
@@ -211,10 +213,17 @@ def route(summary=None, description=None, consumes=None, produces=None,
             route_spec.consumes_content_type = consumes_content_type
         if produces_content_type is not None:
             route_spec.produces_content_type = produces_content_type
+        if exclude is not None:
+            route_spec.exclude = exclude
 
         return func
     return inner
 
+def exclude(boolean):
+    def inner(func):
+        route_specs[func].exclude = boolean
+        return func
+    return inner
 
 def summary(text):
     def inner(func):

--- a/sanic_openapi/openapi.py
+++ b/sanic_openapi/openapi.py
@@ -73,10 +73,11 @@ def build_spec(app, loop):
 
         methods = {}
         for _method, _handler in method_handlers:
-            if _method == 'OPTIONS':
+            route_spec = route_specs.get(_handler) or RouteSpec()
+
+            if _method == 'OPTIONS' or route_spec.exclude:
                 continue
 
-            route_spec = route_specs.get(_handler) or RouteSpec()
             consumes_content_types = route_spec.consumes_content_type or \
                 getattr(app.config, 'API_CONSUMES_CONTENT_TYPES', ['application/json'])
             produces_content_types = route_spec.produces_content_type or \


### PR DESCRIPTION
Hello, I have a use case that requires some routes be excluded from the swagger docs. In our case: we have internally facing health check/status endpoints that are not really part of the API that our consumers will use.

Making a PR to add this feature seemed like the best way to accomplish that:

```
@doc.exclude(True)
async def some_internal_route()
   ...
```

Let me know if this is silly and there's a better way or if it's something you would merge: I can bump the version, write docs and maybe even add a test if so.